### PR TITLE
Add map showing payment locations

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,7 +61,7 @@
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="${MAPS_API_KEY}" />
+            android:value="AIzaSyCASwsCJvFm7dGajUWlVg19PmS8JVPqRaY" />
     </application>
 
 

--- a/app/src/main/java/com/example/msp_app/components/DrawerContainer.kt
+++ b/app/src/main/java/com/example/msp_app/components/DrawerContainer.kt
@@ -87,6 +87,16 @@ fun DrawerContainer(
                                 }
                             }
                         )
+
+                        NavigationDrawerItem(
+                            label = { Text("Mapa de rutas") },
+                            selected = true,
+                            onClick = {
+                                navController.navigate("route_map") {
+                                    popUpTo("home")
+                                }
+                            }
+                        )
                     }
 
                     NavigationDrawerItem(

--- a/app/src/main/java/com/example/msp_app/features/routemap/RouteMapScreen.kt
+++ b/app/src/main/java/com/example/msp_app/features/routemap/RouteMapScreen.kt
@@ -1,0 +1,236 @@
+package com.example.msp_app.features.routes.screens
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.msp_app.components.DrawerContainer
+import com.example.msp_app.core.utils.DateUtils
+import com.example.msp_app.core.utils.ResultState
+import com.example.msp_app.data.models.payment.Payment
+import com.example.msp_app.features.payments.components.paymentitem.PaymentItem
+import com.example.msp_app.features.payments.components.paymentitem.PaymentItemVariant
+import com.example.msp_app.features.payments.viewmodels.PaymentsViewModel
+import com.example.msp_app.features.sales.components.map.MapPin
+import com.example.msp_app.features.sales.components.map.MapView
+import com.google.maps.android.compose.rememberCameraPositionState
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@RequiresApi(Build.VERSION_CODES.S)
+@Composable
+fun RouteMapScreen(
+    navController: NavController,
+    viewModel: PaymentsViewModel = viewModel()
+) {
+    var showDatePicker by remember { mutableStateOf(false) }
+    val datePickerState = rememberDatePickerState()
+    val paymentsState by viewModel.paymentsByDateState.collectAsState()
+    var selectedDate by remember { mutableStateOf(DateUtils.getCurrentDate()) }
+    var textDate by remember { mutableStateOf(TextFieldValue("")) }
+    var reportDateIso by remember { mutableStateOf("") }
+    var visiblePayments by remember { mutableStateOf<List<Payment>>(emptyList()) }
+    val cameraPositionState = rememberCameraPositionState()
+
+
+    fun prepareReportDate(date: LocalDate) {
+        val iso = DateUtils.parseLocalDateToIso(date)
+        val text = TextFieldValue(
+            DateUtils.formatIsoDate(iso, "dd/MM/yyyy", Locale("es", "MX"))
+        )
+        val start = iso
+        val end = DateUtils.addToIsoDate(
+            DateUtils.addToIsoDate(iso, 1, ChronoUnit.DAYS),
+            -1, ChronoUnit.SECONDS
+        )
+        reportDateIso = iso
+        textDate = text
+        selectedDate = date
+        viewModel.getPaymentsByDate(start, end)
+    }
+
+    LaunchedEffect(Unit) {
+        prepareReportDate(selectedDate)
+    }
+
+    LaunchedEffect(datePickerState.selectedDateMillis) {
+        datePickerState.selectedDateMillis?.let { millis ->
+            val date = LocalDate.ofEpochDay(millis / (24 * 60 * 60 * 1000))
+            prepareReportDate(date)
+            showDatePicker = false
+        }
+    }
+
+    val context = LocalContext.current
+
+    DrawerContainer(navController = navController) { openDrawer ->
+        Scaffold(
+            modifier = Modifier.statusBarsPadding(),
+            topBar = {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = openDrawer) {
+                        Icon(Icons.Default.Menu, contentDescription = "Menú")
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text("Mapa de Rutas", style = MaterialTheme.typography.titleLarge)
+                }
+            }
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier
+                    .statusBarsPadding()
+                    .padding(innerPadding)
+                    .padding(horizontal = 16.dp)
+                    .fillMaxSize()
+            ) {
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    Button(
+                        onClick = { showDatePicker = !showDatePicker },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(45.dp),
+                        shape = RoundedCornerShape(25.dp),
+                        colors = ButtonDefaults.buttonColors(containerColor = Color.Blue)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.DateRange,
+                            contentDescription = "Seleccionar fecha",
+                            tint = Color.White
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(text = textDate.text, color = Color.White)
+                    }
+
+                    if (showDatePicker) {
+                        Popup(
+                            onDismissRequest = { showDatePicker = false },
+                            alignment = Alignment.TopStart
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .offset(y = 64.dp)
+                                    .background(MaterialTheme.colorScheme.surface)
+                                    .padding(16.dp)
+                            ) {
+                                DatePicker(
+                                    state = datePickerState,
+                                    showModeToggle = false
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                val pins = visiblePayments.mapNotNull { pago ->
+                    val lat = pago.LAT
+                    val lng = pago.LNG
+                    if (lat != null && lng != null && lat in -90.0..90.0 && lng in -180.0..180.0) {
+                        MapPin(
+                            lat = lat,
+                            lon = lng,
+                            description = pago.NOMBRE_CLIENTE
+                        )
+                    } else null
+                }
+
+                MapView(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(300.dp),
+                    context = context,
+                    pins = pins,
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                when (paymentsState) {
+                    is ResultState.Loading -> {
+                        Text("Cargando pagos...")
+                    }
+
+                    is ResultState.Success -> {
+                        val payments = (paymentsState as ResultState.Success<List<Payment>>).data
+                        LaunchedEffect(payments) {
+                            visiblePayments = payments
+                        }
+
+                        if (payments.isEmpty()) {
+                            Text("No hay pagos para esta fecha.")
+                        } else {
+                            LazyColumn(modifier = Modifier.weight(1f)) {
+                                items(visiblePayments, key = { it.hashCode() }) { pago ->
+                                    PaymentItem(
+                                        pago,
+                                        variant = PaymentItemVariant.DEFAULT,
+                                        navController = navController
+                                    )
+                                }
+                                item { Spacer(modifier = Modifier.height(12.dp)) }
+                            }
+                        }
+                    }
+
+                    is ResultState.Error -> {
+                        Text("Error: ${(paymentsState as ResultState.Error).message}")
+                    }
+
+                    else -> {
+                        Text("Selecciona una fecha para ver los pagos.")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/msp_app/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/msp_app/navigation/AppNavigation.kt
@@ -18,6 +18,7 @@ import com.example.msp_app.features.guarantees.screens.GuaranteeScreen
 import com.example.msp_app.features.home.screens.HomeScreen
 import com.example.msp_app.features.payments.screens.DailyReportScreen
 import com.example.msp_app.features.payments.screens.WeeklyReportScreen
+import com.example.msp_app.features.routes.screens.RouteMapScreen
 import com.example.msp_app.features.sales.screens.MapScreen
 import com.example.msp_app.features.sales.screens.SaleDetailsScreen
 import com.example.msp_app.features.sales.screens.SalesScreen
@@ -39,6 +40,7 @@ sealed class Screen(val route: String) {
     }
 
     object Guarantee : Screen("guarantee")
+    object RouteMap : Screen("route_map")
 }
 
 @RequiresApi(Build.VERSION_CODES.S)
@@ -101,6 +103,10 @@ fun AppNavigation() {
 
             composable(Screen.Guarantee.route) {
                 GuaranteeScreen(navController = navController)
+            }
+
+            composable(Screen.RouteMap.route) {
+                RouteMapScreen(navController = navController)
             }
         }
     }


### PR DESCRIPTION
A screen displaying a map showing payments made on a specific date. It allows you to select the date from a DatePicker and view the payments made that day on the map using geotagged pins, focusing the view on the closest group of locations.