### PR TITLE
show total cash and transfer in report

### DIFF
--- a/app/src/main/java/com/example/msp_app/core/utils/PdfGenerator.kt
+++ b/app/src/main/java/com/example/msp_app/core/utils/PdfGenerator.kt
@@ -107,6 +107,23 @@ object PdfGenerator {
         yPos += lineSpacing
         canvas.drawText(totalAmountsText, xTotalAmounts, yPos.toFloat(), paint)
 
+        yPos += lineSpacing
+        data.breakdownByMethod.forEach { breakdown ->
+            if (yPos > pageHeight - 80) {
+                pdfDocument.finishPage(page)
+                page = pdfDocument.startPage(pageInfo)
+                canvas = page.canvas
+                yPos = 40
+            }
+
+            val label = "${breakdown.method.label} (${breakdown.count} pagos): ${
+                breakdown.amount.toCurrency(noDecimals = true)
+            }"
+            val xLabel = pageWidth - rightMargin - paint.measureText(label)
+            canvas.drawText(label, xLabel, yPos.toFloat(), paint)
+            yPos += lineSpacing
+        }
+
         pdfDocument.finishPage(page)
 
         val file = File(context.cacheDir, fileName)

--- a/app/src/main/java/com/example/msp_app/features/payments/screens/DailyReportScreen.kt
+++ b/app/src/main/java/com/example/msp_app/features/payments/screens/DailyReportScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
@@ -105,7 +104,7 @@ private fun buildPaymentsTicketText(
     builder.appendLine("Fecha: $dateStr")
     builder.appendLine("Cobrador: $collectorName")
     builder.appendLine("-".repeat(32))
-    builder.appendLine(String.format("%-6s %-16s %8s", "Fecha", "Cliente", "Importe"))
+    builder.appendLine(String.format("%-6s %-16s %8s", "Hora", "Cliente", "Importe"))
     payments.forEach { pago ->
         val date = DateUtils.formatIsoDate(pago.FECHA_HORA_PAGO, "HH:mm", Locale("es", "MX"))
         val client = pago.NOMBRE_CLIENTE.takeIf { it.length <= 16 } ?: pago.NOMBRE_CLIENTE.take(16)
@@ -119,8 +118,20 @@ private fun buildPaymentsTicketText(
         )
     }
     builder.appendLine("-".repeat(32))
-    builder.appendLine("Total pagos: ${payments.size}")
-    builder.appendLine("Total importe: $%,d".format(payments.sumOf { it.IMPORTE }.toInt()))
+    val total = payments.sumOf { it.IMPORTE }.toInt()
+    val cash =
+        payments.filter { PaymentMethod.fromId(it.FORMA_COBRO_ID) == PaymentMethod.PAGO_EN_EFECTIVO }
+    val transfers =
+        payments.filter { PaymentMethod.fromId(it.FORMA_COBRO_ID) == PaymentMethod.PAGO_CON_TRANSFERENCIA }
+
+    val totalCash = cash.sumOf { it.IMPORTE }.toInt()
+    val totalTransfers = transfers.sumOf { it.IMPORTE }.toInt()
+
+    builder.appendLine("Total payments: ${payments.size}")
+    builder.appendLine("Total importe: $%,d".format(total))
+    builder.appendLine("Efectivo (${cash.size} pagos): $%,d".format(totalCash))
+    builder.appendLine("Transferencia (${transfers.size} pagos): $%,d".format(totalTransfers))
+
     return builder.toString()
 }
 
@@ -134,7 +145,6 @@ fun DailyReportScreen(
     var showDatePicker by remember { mutableStateOf(false) }
     var textDate by remember { mutableStateOf(TextFieldValue("")) }
     val datePickerState = rememberDatePickerState()
-    val scrollState = rememberScrollState()
     val paymentsState by viewModel.paymentsByDateState.collectAsState()
     var visiblePayments by remember { mutableStateOf<List<Payment>>(emptyList()) }
     var reportDateIso by remember { mutableStateOf("") }
@@ -158,7 +168,7 @@ fun DailyReportScreen(
             }
         }
     }
-    
+
     val ticketText by remember(visiblePayments, textDate.text) {
         derivedStateOf {
             buildPaymentsTicketText(
@@ -254,7 +264,7 @@ fun DailyReportScreen(
                 ) {
                     when (paymentsState) {
                         is ResultState.Loading -> {
-                            Text("Cargando pagos...")
+                            Text("Cargando payments...")
                         }
 
                         is ResultState.Success -> {
@@ -275,7 +285,7 @@ fun DailyReportScreen(
                                 )
 
                             if (payments.isEmpty()) {
-                                Text("No hay pagos para esta fecha.")
+                                Text("No hay payments para esta fecha.")
                             } else {
                                 val formatter = DateTimeFormatter.ISO_DATE_TIME
 
@@ -420,7 +430,7 @@ fun DailyReportScreen(
                         }
 
                         else -> {
-                            Text("Selecciona una fecha para ver los pagos.")
+                            Text("Selecciona una fecha para ver los payments.")
                         }
                     }
                 }
@@ -436,10 +446,17 @@ data class PaymentLineData(
     val paymentMethod: PaymentMethod,
 )
 
+data class PaymentMethodBreakdown(
+    val method: PaymentMethod,
+    val count: Int,
+    val amount: Double
+)
+
 data class PaymentTextData(
     val lines: List<PaymentLineData>,
     val totalCount: Int,
-    val totalAmount: Double
+    val totalAmount: Double,
+    val breakdownByMethod: List<PaymentMethodBreakdown> = emptyList()
 )
 
 fun formatPaymentsTextList(payments: List<Payment>): PaymentTextData {
@@ -459,6 +476,15 @@ fun formatPaymentsTextList(payments: List<Payment>): PaymentTextData {
 
     val totalCount = payments.size
     val totalAmount = payments.sumOf { it.IMPORTE }
+    val breakdownByMethod = payments
+        .groupBy { PaymentMethod.fromId(it.FORMA_COBRO_ID) }
+        .map { (method, payments) ->
+            PaymentMethodBreakdown(
+                method = method,
+                count = payments.size,
+                amount = payments.sumOf { it.IMPORTE }
+            )
+        }
 
-    return PaymentTextData(lines, totalCount, totalAmount)
+    return PaymentTextData(lines, totalCount, totalAmount, breakdownByMethod)
 }

--- a/app/src/main/java/com/example/msp_app/features/payments/screens/DailyReportScreen.kt
+++ b/app/src/main/java/com/example/msp_app/features/payments/screens/DailyReportScreen.kt
@@ -127,7 +127,7 @@ private fun buildPaymentsTicketText(
     val totalCash = cash.sumOf { it.IMPORTE }.toInt()
     val totalTransfers = transfers.sumOf { it.IMPORTE }.toInt()
 
-    builder.appendLine("Total payments: ${payments.size}")
+    builder.appendLine("Total de pagos: ${payments.size}")
     builder.appendLine("Total importe: $%,d".format(total))
     builder.appendLine("Efectivo (${cash.size} pagos): $%,d".format(totalCash))
     builder.appendLine("Transferencia (${transfers.size} pagos): $%,d".format(totalTransfers))
@@ -264,7 +264,7 @@ fun DailyReportScreen(
                 ) {
                     when (paymentsState) {
                         is ResultState.Loading -> {
-                            Text("Cargando payments...")
+                            Text("Cargando pagos...")
                         }
 
                         is ResultState.Success -> {
@@ -285,7 +285,7 @@ fun DailyReportScreen(
                                 )
 
                             if (payments.isEmpty()) {
-                                Text("No hay payments para esta fecha.")
+                                Text("No hay pagos para esta fecha.")
                             } else {
                                 val formatter = DateTimeFormatter.ISO_DATE_TIME
 
@@ -430,7 +430,7 @@ fun DailyReportScreen(
                         }
 
                         else -> {
-                            Text("Selecciona una fecha para ver los payments.")
+                            Text("Selecciona una fecha para ver los pago.")
                         }
                     }
                 }

--- a/app/src/main/java/com/example/msp_app/features/routemap/RouteMapScreen.kt
+++ b/app/src/main/java/com/example/msp_app/features/routemap/RouteMapScreen.kt
@@ -220,12 +220,12 @@ fun RouteMapScreen(
 
                 when (paymentsState) {
                     is ResultState.Loading -> {
-                        Text("Cargando payments...")
+                        Text("Cargando pagos...")
                     }
 
                     is ResultState.Success -> {
                         if (visiblePayments.isEmpty()) {
-                            Text("No hay payments para esta fecha.")
+                            Text("No hay pagos para esta fecha.")
                         } else {
                             LazyColumn(modifier = Modifier.weight(1f)) {
                                 items(visiblePayments, key = { it.hashCode() }) { payment ->
@@ -252,7 +252,7 @@ fun RouteMapScreen(
                     }
 
                     else -> {
-                        Text("Selecciona una fecha para ver los payments.")
+                        Text("Selecciona una fecha para ver los pagos.")
                     }
                 }
             }


### PR DESCRIPTION
Adds payment method breakdown (cash and transfer) to the weekly PDF report, including separate subtotals for each method, similar to the daily report.
