### PR TITLE
Add visits to the PDF report

### DIFF
--- a/app/src/main/java/com/example/msp_app/data/local/dao/visit/VisitDao.kt
+++ b/app/src/main/java/com/example/msp_app/data/local/dao/visit/VisitDao.kt
@@ -57,6 +57,29 @@ interface VisitDao {
     )
     suspend fun getPendingVisits(): List<VisitEntity>
 
+    @Query(
+        """
+        SELECT 
+            ID,
+            CLIENTE_ID,
+            COBRADOR,
+            COBRADOR_ID,
+            FECHA,
+            FORMA_COBRO_ID,
+            LAT,
+            LNG,
+            NOTA,
+            TIPO_VISITA,
+            ZONA_CLIENTE_ID,
+            IMPTE_DOCTO_CC_ID,
+            GUARDADO_EN_MICROSIP
+        FROM Visit
+        WHERE FECHA BETWEEN :start AND :end
+        ORDER BY FECHA DESC
+        """
+    )
+    suspend fun getVisitsByDate(start: String, end: String): List<VisitEntity>
+
     @Query("UPDATE Visit SET GUARDADO_EN_MICROSIP = :newState WHERE id = :id")
     suspend fun updateState(id: String, newState: Int)
 

--- a/app/src/main/java/com/example/msp_app/data/local/datasource/visit/VisitsLocalDataSource.kt
+++ b/app/src/main/java/com/example/msp_app/data/local/datasource/visit/VisitsLocalDataSource.kt
@@ -22,6 +22,10 @@ class VisitsLocalDataSource(private val context: Context) {
         return visitDao.getPendingVisits()
     }
 
+    suspend fun getVisitsByDate(start: String, end: String): List<VisitEntity> {
+        return visitDao.getVisitsByDate(start, end)
+    }
+
     suspend fun updateVisitState(id: String, newState: Int) {
         visitDao.updateState(id, newState)
     }

--- a/app/src/main/java/com/example/msp_app/features/payments/screens/WeeklyReportScreen.kt
+++ b/app/src/main/java/com/example/msp_app/features/payments/screens/WeeklyReportScreen.kt
@@ -51,6 +51,7 @@ import com.example.msp_app.data.models.payment.Payment
 import com.example.msp_app.features.payments.components.paymentitem.PaymentItem
 import com.example.msp_app.features.payments.components.paymentitem.PaymentItemVariant
 import com.example.msp_app.features.payments.viewmodels.PaymentsViewModel
+import com.example.msp_app.features.visit.viewmodels.VisitsViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -80,9 +81,12 @@ fun WeeklyReportScreen(
         DateUtils.addToIsoDate(startIso, 6, ChronoUnit.DAYS),
         -1, ChronoUnit.SECONDS
     )
+    val visitsViewModel: VisitsViewModel = viewModel()
+    val visitsState by visitsViewModel.visitsByDate.collectAsState()
 
     LaunchedEffect(startIso) {
         viewModel.getPaymentsByDate(startIso, endIso)
+        visitsViewModel.getVisitsByDate(startIso, endIso)
     }
 
     fun formatPaymentsTextList(payments: List<Payment>): PaymentTextData {
@@ -257,10 +261,15 @@ fun WeeklyReportScreen(
                                             isGeneratingPdf = true
                                             val paymentTextData =
                                                 formatPaymentsTextList(visiblePayments)
+                                            val visitTextData = formatVisitsTextList(
+                                                (visitsState as? ResultState.Success)?.data
+                                                    ?: emptyList()
+                                            )
                                             val file = withContext(Dispatchers.IO) {
                                                 PdfGenerator.generatePdfFromLines(
                                                     context = context,
                                                     data = paymentTextData,
+                                                    visits = visitTextData,
                                                     title = "REPORTE DE PAGOS SEMANAL",
                                                     nameCollector = visiblePayments.firstOrNull()?.COBRADOR
                                                         ?: "No especificado",

--- a/app/src/main/java/com/example/msp_app/features/visit/viewmodels/VisitsViewModel.kt
+++ b/app/src/main/java/com/example/msp_app/features/visit/viewmodels/VisitsViewModel.kt
@@ -28,6 +28,9 @@ class VisitsViewModel(application: Application) : AndroidViewModel(application) 
     private val _saveVisitState = MutableStateFlow<ResultState<Unit>>(ResultState.Idle)
     val savePaymentState: StateFlow<ResultState<Unit>> = _saveVisitState
 
+    private val _visitsByDateState = MutableStateFlow<ResultState<List<Visit>>>(ResultState.Idle)
+    val visitsByDate: StateFlow<ResultState<List<Visit>>> = _visitsByDateState
+
     fun getPendingVisits() {
         viewModelScope.launch {
             _pendingVisits.value = ResultState.Loading
@@ -61,6 +64,18 @@ class VisitsViewModel(application: Application) : AndroidViewModel(application) 
             } catch (e: Exception) {
                 _saveVisitState.value = ResultState.Error(e.message ?: "Error guardando pago")
             }
+        }
+    }
+
+    fun getVisitsByDate(startDate: String, endDate: String) {
+        viewModelScope.launch {
+            _visitsByDateState.value = ResultState.Loading
+
+            val visits = withContext(Dispatchers.IO) {
+                visitStore.getVisitsByDate(startDate, endDate)
+                    .map { it.toDomain() }
+            }
+            _visitsByDateState.value = ResultState.Success(visits)
         }
     }
 }


### PR DESCRIPTION
Include in the PDF report not only the day's payments, but also the visits made, providing a complete summary of the day.
