### PR TITLE
Add listener in Firestore for dynamic base URL update

### DIFF
--- a/app/src/main/java/com/example/msp_app/core/utils/Constants.kt
+++ b/app/src/main/java/com/example/msp_app/core/utils/Constants.kt
@@ -31,4 +31,13 @@ object Constants {
     //Datos para ticket
     const val WHATSAPP = "238-374-06-84"
     const val TELEFONO = "238-110-50-61"
+
+    //Firebase Collection
+    const val COLLECTION_CONFIG = "config"
+
+    //Firebase Document
+    const val DOCUMENT_API_SETTINGS = "api_settings"
+
+    //Firebase Field
+    const val FIELD_BASE_URL = "baseURL"
 }

--- a/app/src/main/java/com/example/msp_app/data/api/ApiProvider.kt
+++ b/app/src/main/java/com/example/msp_app/data/api/ApiProvider.kt
@@ -1,5 +1,8 @@
 package com.example.msp_app.data.api
 
+import com.example.msp_app.core.utils.Constants.COLLECTION_CONFIG
+import com.example.msp_app.core.utils.Constants.DOCUMENT_API_SETTINGS
+import com.example.msp_app.core.utils.Constants.FIELD_BASE_URL
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
 import kotlinx.coroutines.CoroutineScope
@@ -14,21 +17,20 @@ object ApiProvider : BaseApi() {
     private const val DEFAULT_BASE_URL = "https://msp2025.loclx.io/"
     private val _baseURL = MutableStateFlow(DEFAULT_BASE_URL)
     val baseURL: StateFlow<String> = _baseURL
-
     private var retrofitInstance: Retrofit? = null
     private var firestoreListener: ListenerRegistration? = null
 
     init {
         firestoreListener = FirebaseFirestore.getInstance()
-            .collection("config")
-            .document("api_settings")
+            .collection(COLLECTION_CONFIG)
+            .document(DOCUMENT_API_SETTINGS)
             .addSnapshotListener { snapshot, error ->
                 if (error != null) {
                     println("Error al escuchar base URL: ${error.message}")
                     return@addSnapshotListener
                 }
                 if (snapshot != null && snapshot.exists()) {
-                    val newUrl = snapshot.getString("baseURL") ?: DEFAULT_BASE_URL
+                    val newUrl = snapshot.getString(FIELD_BASE_URL) ?: DEFAULT_BASE_URL
                     if (newUrl.isNotEmpty() && newUrl != _baseURL.value) {
                         _baseURL.value = newUrl
                         CoroutineScope(Dispatchers.IO).launch {

--- a/app/src/main/java/com/example/msp_app/data/api/ApiProvider.kt
+++ b/app/src/main/java/com/example/msp_app/data/api/ApiProvider.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 import retrofit2.Retrofit
 
 object ApiProvider : BaseApi() {
@@ -20,18 +19,6 @@ object ApiProvider : BaseApi() {
     private var firestoreListener: ListenerRegistration? = null
 
     init {
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                val firestoreUrl = getBaseUrlFromFirestore()
-                if (firestoreUrl.isNotEmpty() && firestoreUrl != _baseURL.value) {
-                    _baseURL.value = firestoreUrl
-                    retrofitInstance = createClient(_baseURL.value)
-                }
-            } catch (e: Exception) {
-                println("No se pudo cargar base URL desde Firestore: ${e.message}")
-            }
-        }
-
         firestoreListener = FirebaseFirestore.getInstance()
             .collection("config")
             .document("api_settings")
@@ -60,15 +47,5 @@ object ApiProvider : BaseApi() {
 
     fun <T> create(service: Class<T>): T {
         return getRetrofit().create(service)
-    }
-
-    private suspend fun getBaseUrlFromFirestore(): String {
-        val snapshot = FirebaseFirestore.getInstance()
-            .collection("config")
-            .document("api_settings")
-            .get()
-            .await()
-
-        return snapshot.getString("baseURL") ?: ""
     }
 }

--- a/app/src/main/java/com/example/msp_app/data/api/ApiProvider.kt
+++ b/app/src/main/java/com/example/msp_app/data/api/ApiProvider.kt
@@ -1,13 +1,74 @@
 package com.example.msp_app.data.api
 
-object ApiProvider : BaseApi() {
-    private const val BASE_URL = "https://msp2025.loclx.io/"
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ListenerRegistration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import retrofit2.Retrofit
 
-    val retrofit by lazy {
-        createClient(BASE_URL)
+object ApiProvider : BaseApi() {
+
+    private const val DEFAULT_BASE_URL = "https://msp2025.loclx.io/"
+    private val _baseURL = MutableStateFlow(DEFAULT_BASE_URL)
+    val baseURL: StateFlow<String> = _baseURL
+
+    private var retrofitInstance: Retrofit? = null
+    private var firestoreListener: ListenerRegistration? = null
+
+    init {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val firestoreUrl = getBaseUrlFromFirestore()
+                if (firestoreUrl.isNotEmpty() && firestoreUrl != _baseURL.value) {
+                    _baseURL.value = firestoreUrl
+                    retrofitInstance = createClient(_baseURL.value)
+                }
+            } catch (e: Exception) {
+                println("No se pudo cargar base URL desde Firestore: ${e.message}")
+            }
+        }
+
+        firestoreListener = FirebaseFirestore.getInstance()
+            .collection("config")
+            .document("api_settings")
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    println("Error al escuchar base URL: ${error.message}")
+                    return@addSnapshotListener
+                }
+                if (snapshot != null && snapshot.exists()) {
+                    val newUrl = snapshot.getString("baseURL") ?: DEFAULT_BASE_URL
+                    if (newUrl.isNotEmpty() && newUrl != _baseURL.value) {
+                        _baseURL.value = newUrl
+                        CoroutineScope(Dispatchers.IO).launch {
+                            retrofitInstance = createClient(newUrl)
+                        }
+                    }
+                }
+            }
+    }
+
+    private fun getRetrofit(): Retrofit {
+        return retrofitInstance ?: synchronized(this) {
+            retrofitInstance ?: createClient(_baseURL.value).also { retrofitInstance = it }
+        }
     }
 
     fun <T> create(service: Class<T>): T {
-        return retrofit.create(service)
+        return getRetrofit().create(service)
+    }
+
+    private suspend fun getBaseUrlFromFirestore(): String {
+        val snapshot = FirebaseFirestore.getInstance()
+            .collection("config")
+            .document("api_settings")
+            .get()
+            .await()
+
+        return snapshot.getString("baseURL") ?: ""
     }
 }

--- a/app/src/main/java/com/example/msp_app/features/home/components/homefootersection/HomeFooterSection.kt
+++ b/app/src/main/java/com/example/msp_app/features/home/components/homefootersection/HomeFooterSection.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.msp_app.core.utils.Constants.APP_VERSION
 import com.example.msp_app.core.utils.ResultState
+import com.example.msp_app.data.api.ApiProvider
 import com.example.msp_app.data.models.payment.Payment
 import com.example.msp_app.data.models.visit.Visit
 
@@ -193,6 +194,13 @@ fun HomeFooterSection(
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
             modifier = Modifier.padding(8.dp),
             fontSize = 16.sp
+        )
+
+        Text(
+            text = "URL base: ${ApiProvider.baseURL.value}",
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+            modifier = Modifier.padding(bottom = 8.dp),
+            fontSize = 14.sp
         )
     }
 }

--- a/app/src/main/java/com/example/msp_app/features/home/components/homefootersection/HomeFooterSection.kt
+++ b/app/src/main/java/com/example/msp_app/features/home/components/homefootersection/HomeFooterSection.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -48,6 +49,7 @@ fun HomeFooterSection(
     modifier: Modifier = Modifier
 ) {
     val showDialogInitWeek = remember { mutableStateOf(false) }
+    val baseURL = ApiProvider.baseURL.collectAsState()
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -197,7 +199,7 @@ fun HomeFooterSection(
         )
 
         Text(
-            text = "URL base: ${ApiProvider.baseURL.value}",
+            text = "URL base: ${baseURL.value}",
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
             modifier = Modifier.padding(bottom = 8.dp),
             fontSize = 14.sp

--- a/app/src/main/java/com/example/msp_app/features/payments/viewmodels/PaymentsViewModel.kt
+++ b/app/src/main/java/com/example/msp_app/features/payments/viewmodels/PaymentsViewModel.kt
@@ -27,7 +27,7 @@ import java.time.format.DateTimeFormatter
 
 class PaymentsViewModel(application: Application) : AndroidViewModel(application) {
     private val paymentStore = PaymentsLocalDataSource(application.applicationContext)
-    private val api = ApiProvider.create(PaymentsApi::class.java)
+    private val api: PaymentsApi get() = ApiProvider.create(PaymentsApi::class.java)
 
     private val _paymentsBySaleIdState =
         MutableStateFlow<ResultState<List<Payment>>>(ResultState.Idle)

--- a/app/src/main/java/com/example/msp_app/features/sales/viewmodels/SalesViewModel.kt
+++ b/app/src/main/java/com/example/msp_app/features/sales/viewmodels/SalesViewModel.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.launch
 
 
 class SalesViewModel(application: Application) : AndroidViewModel(application) {
-    private val api = ApiProvider.create(SalesApi::class.java)
+    private val api: SalesApi get() = ApiProvider.create(SalesApi::class.java)
     private val saleStore = SalesLocalDataSource(application.applicationContext)
     private val productStore = ProductsLocalDataSource(application.applicationContext)
     private val paymentStore = PaymentsLocalDataSource(application.applicationContext)

--- a/app/src/main/java/com/example/msp_app/features/visit/viewmodels/VisitsViewModel.kt
+++ b/app/src/main/java/com/example/msp_app/features/visit/viewmodels/VisitsViewModel.kt
@@ -22,7 +22,7 @@ class VisitsViewModel(application: Application) : AndroidViewModel(application) 
     private val visitStore = VisitsLocalDataSource(application.applicationContext)
     private val saleStore = VisitsLocalDataSource(application.applicationContext)
 
-    private val api = ApiProvider.create(VisitsApi::class.java)
+    private val api: VisitsApi get() = ApiProvider.create(VisitsApi::class.java)
 
     private val _pendingVisits = MutableStateFlow<ResultState<List<Visit>>>(ResultState.Idle)
     val pendingVisits: StateFlow<ResultState<List<Visit>>> = _pendingVisits


### PR DESCRIPTION
This PR adds a listener on ApiProvider to dynamically update the API base URL from Firestore in real time.