### PR TITLE
show forgiveness as a payment method

### DIFF
--- a/app/src/main/java/com/example/msp_app/features/payments/screens/PaymentTicketScreen.kt
+++ b/app/src/main/java/com/example/msp_app/features/payments/screens/PaymentTicketScreen.kt
@@ -205,7 +205,7 @@ fun PaymentTicketScreen(
                             ticket = buildString {
                                 appendLine(
                                     ThermalPrinting.centerText(
-                                        if (isCondonacion) "TICKET DE CONDONACIÓN" else "TICKET DE PAGO",
+                                        if (isCondonacion) "TICKET DE CONDONACION" else "TICKET DE PAGO",
                                         32
                                     )
                                 )
@@ -260,7 +260,7 @@ fun PaymentTicketScreen(
                                 appendLine(lineBlanck)
                                 appendLine("-".repeat(32))
                                 appendLine(lineBlanck)
-                                appendLine(if (isCondonacion) "FECHA DE CONDONACIÓN: ${date}" else "FECHA DE PAGO: ${date}")
+                                appendLine(if (isCondonacion) "FECHA DE CONDONACION: ${date}" else "FECHA DE PAGO: ${date}")
                                 appendLine(
                                     "SALDO ANTERIOR: ${
                                         ThermalPrinting.bold(

--- a/app/src/main/java/com/example/msp_app/features/payments/screens/PaymentTicketScreen.kt
+++ b/app/src/main/java/com/example/msp_app/features/payments/screens/PaymentTicketScreen.kt
@@ -260,7 +260,7 @@ fun PaymentTicketScreen(
                                 appendLine(lineBlanck)
                                 appendLine("-".repeat(32))
                                 appendLine(lineBlanck)
-                                appendLine("FECHA DE PAGO: ${date}")
+                                appendLine(if (isCondonacion) "FECHA DE CONDONACIÓN: ${date}" else "FECHA DE PAGO: ${date}")
                                 appendLine(
                                     "SALDO ANTERIOR: ${
                                         ThermalPrinting.bold(

--- a/app/src/main/java/com/example/msp_app/features/payments/screens/PaymentTicketScreen.kt
+++ b/app/src/main/java/com/example/msp_app/features/payments/screens/PaymentTicketScreen.kt
@@ -95,6 +95,9 @@ fun PaymentTicketScreen(
     val productsResult by productsViewModel.productsByFolioState.collectAsState()
 
     var selectedPayment by remember { mutableStateOf<Payment?>(null) }
+    val isCondonacion = selectedPayment?.let {
+        PaymentMethod.fromId(it.FORMA_COBRO_ID).label.equals("Condonación", ignoreCase = true)
+    } ?: false
     var ticket by remember { mutableStateOf<String?>(null) }
     var saleDisponible by remember { mutableStateOf(false) }
 
@@ -200,7 +203,12 @@ fun PaymentTicketScreen(
                             val lineBlanck = (" ").repeat(32)
 
                             ticket = buildString {
-                                appendLine(ThermalPrinting.centerText("TICKET DE PAGO", 32))
+                                appendLine(
+                                    ThermalPrinting.centerText(
+                                        if (isCondonacion) "TICKET DE CONDONACIÓN" else "TICKET DE PAGO",
+                                        32
+                                    )
+                                )
                                 appendLine(lineBlanck)
                                 appendLine("FOLIO: ${sale?.FOLIO}")
                                 appendLine("CLIENTE: ${sale?.CLIENTE}")
@@ -329,7 +337,7 @@ fun PaymentTicketScreen(
                                         contentAlignment = Alignment.Center
                                     ) {
                                         Text(
-                                            text = "Ticket de Pago",
+                                            text = if (isCondonacion) "Ticket de Condonación" else "Ticket de Pago",
                                             fontSize = 24.sp,
                                             fontWeight = FontWeight.Bold,
                                         )


### PR DESCRIPTION
Adds support for displaying "Sorry" as a payment method on printed receipts if the payment was recorded using that method.