### PR TITLE
 Fix: Use ID instead of hashCode() to display payments correctly

### DIFF
--- a/app/src/main/java/com/example/msp_app/features/payments/screens/DailyReportScreen.kt
+++ b/app/src/main/java/com/example/msp_app/features/payments/screens/DailyReportScreen.kt
@@ -382,7 +382,7 @@ fun DailyReportScreen(
                                     item { Spacer(modifier = Modifier.height(2.dp)) }
                                     items(
                                         visiblePayments,
-                                        key = { it.hashCode() }
+                                        key = { it.ID }
                                     ) { pago ->
                                         PaymentItem(
                                             pago,


### PR DESCRIPTION
Replaced the use of hashCode() with ID in the DailyReportScreen for the payment list (LazyColumn).
hashCode() is not guaranteed to be unique. Two different objects can return the same number.
Jetpack Compose uses the key to detect changes, insertions, or deletions in the list.
If Compose confuses two items with the same hashCode, it can hide or mix up payments, even if they exist in the database.