### PR TITLE
Use ID instead of hashCode() to display payments correctly

### DIFF
--- a/app/src/main/java/com/example/msp_app/features/routemap/RouteMapScreen.kt
+++ b/app/src/main/java/com/example/msp_app/features/routemap/RouteMapScreen.kt
@@ -230,7 +230,7 @@ fun RouteMapScreen(
                             Text("No hay pagos para esta fecha.")
                         } else {
                             LazyColumn(modifier = Modifier.weight(1f)) {
-                                items(visiblePayments, key = { it.hashCode() }) { payment ->
+                                items(visiblePayments, key = { it.ID }) { payment ->
                                     PaymentItem(
                                         payment = payment,
                                         variant = PaymentItemVariant.DEFAULT,


### PR DESCRIPTION
Use ID instead of hashCode() to display payments correctly, this in the RouteMapScreen screen