### PR TITLE
add functionality to save images to gallery

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,4 +143,6 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.2")
     implementation("com.google.code.gson:gson:2.8.9")
     implementation("androidx.biometric:biometric:1.1.0")
+    implementation("androidx.compose.material:material-icons-extended")
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,14 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/msp_app/core/utils/SaveImageToGallery.kt
+++ b/app/src/main/java/com/example/msp_app/core/utils/SaveImageToGallery.kt
@@ -1,0 +1,51 @@
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.provider.MediaStore
+import android.widget.Toast
+import java.io.File
+
+fun saveImageToGallery(context: Context, uri: Uri) {
+    try {
+        val file = File(uri.path ?: "")
+        if (!file.exists()) {
+            Toast.makeText(context, "Error: archivo no encontrado", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val inputStream = file.inputStream()
+        val filename = "venta_${System.currentTimeMillis()}.jpg"
+
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, filename)
+            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+            put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/MSP_App")
+        }
+
+        val resolver = context.contentResolver
+        val imageUri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+
+        if (imageUri == null) {
+            Toast.makeText(
+                context,
+                "Error: no se pudo crear archivo en galería",
+                Toast.LENGTH_SHORT
+            ).show()
+            return
+        }
+
+        resolver.openOutputStream(imageUri).use { outputStream ->
+            if (outputStream == null) {
+                Toast.makeText(context, "Error: no se pudo escribir la imagen", Toast.LENGTH_SHORT)
+                    .show()
+                return
+            }
+            inputStream.copyTo(outputStream)
+        }
+
+        Toast.makeText(context, "✅ Imagen guardada en la galería", Toast.LENGTH_SHORT).show()
+    } catch (e: Exception) {
+        Toast.makeText(context, "Error: ${e.message}", Toast.LENGTH_SHORT).show()
+    }
+}
+

--- a/app/src/main/java/com/example/msp_app/features/productsInventory/components/CarrouselImage.kt
+++ b/app/src/main/java/com/example/msp_app/features/productsInventory/components/CarrouselImage.kt
@@ -34,9 +34,11 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.core.net.toUri
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.request.ImageRequest
+import saveImageToGallery
 import java.io.File
 
 data class CarouselItem(
@@ -130,6 +132,7 @@ fun ZoomableImageDialog1(
     var offsetX by remember { mutableFloatStateOf(0f) }
     var offsetY by remember { mutableFloatStateOf(0f) }
     val context = LocalContext.current
+    val imageUri = File(item.imagePath).toUri()
 
     val imageModifier = Modifier
         .fillMaxWidth()
@@ -183,24 +186,43 @@ fun ZoomableImageDialog1(
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))
-
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Button(onClick = {
-                        scale = 1f
-                        offsetX = 0f
-                        offsetY = 0f
-                    }) {
-                        Text(
-                            "Restaurar",
-                            color = Color.White
-                        )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Button(
+                        onClick = {
+                            scale = 1f
+                            offsetX = 0f
+                            offsetY = 0f
+                        },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("Restaurar", color = Color.White)
                     }
 
-                    Button(onClick = onDismiss) {
-                        Text(
-                            "Cerrar",
-                            color = Color.White
-                        )
+                    Button(
+                        onClick = {
+                            val imageUri = File(item.imagePath).toUri()
+                            saveImageToGallery(context, imageUri)
+                        },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("Descargar Imagen")
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Button(
+                        onClick = onDismiss,
+                        modifier = Modifier.fillMaxWidth(0.5f)
+                    ) {
+                        Text("Cerrar", color = Color.White)
                     }
                 }
             }

--- a/app/src/main/java/com/example/msp_app/features/sales/components/saleimagesviewer/SaleImagesViewer.kt
+++ b/app/src/main/java/com/example/msp_app/features/sales/components/saleimagesviewer/SaleImagesViewer.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -33,10 +34,12 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import coil.compose.rememberAsyncImagePainter
+import saveImageToGallery
 
 @Composable
 fun ImageViewerDialog(
@@ -52,6 +55,8 @@ fun ImageViewerDialog(
         scale = (scale * zoomChange).coerceIn(0.5f, 5f)
         offset += offsetChange
     }
+    val context = LocalContext.current
+
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -80,6 +85,25 @@ fun ImageViewerDialog(
                         .transformable(state = transformableState),
                     contentScale = ContentScale.Fit
                 )
+
+                IconButton(
+                    onClick = {
+                        saveImageToGallery(context, imageUris[currentIndex])
+                    },
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(16.dp)
+                        .background(
+                            Color.Black.copy(alpha = 0.5f),
+                            shape = CircleShape
+                        )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Download,
+                        contentDescription = "Descargar",
+                        tint = Color.White
+                    )
+                }
 
                 IconButton(
                     onClick = onDismiss,


### PR DESCRIPTION
Added the option to download images from the carousel and save them to the device gallery.
Added buttons in the image zoom dialog to restore zoom and download the image.
Maintained compatibility with the existing download functionality in other screens.