### PR TITLE
fix(search): Normalize phone numbers by removing spaces and dashes

### DIFF
--- a/app/src/main/java/com/example/msp_app/core/utils/FuzzyClientSearch.kt
+++ b/app/src/main/java/com/example/msp_app/core/utils/FuzzyClientSearch.kt
@@ -41,7 +41,9 @@ fun <T> searchSimilarItems(
 
 private fun normalize(text: String): String {
     val nfd = Normalizer.normalize(text.trim().lowercase(), Normalizer.Form.NFD)
-    return nfd.replace("\\p{M}".toRegex(), "")
+    val withoutAccents = nfd.replace("\\p{M}".toRegex(), "")
+
+    return withoutAccents.replace(Regex("[\\s\\-().]"), "")
 }
 
 private fun longestCommonSubstring(s1: String, s2: String): Int {


### PR DESCRIPTION
- Remove formatting characters (spaces, dashes, parentheses, dots)
- Allow searching phone numbers without formatting and find matches